### PR TITLE
toolz 0.12.0

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,17 +1,17 @@
-{% set version = "0.11.2" %}
+{% set name = "toolz" %}
+{% set version = "0.12.0" %}
 
 package:
-  name: toolz
+  name: {{ name|lower }}
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/t/toolz/toolz-{{ version }}.tar.gz
-  sha256: 6b312d5e15138552f1bda8a4e66c30e236c831b612b2bf0005f8a1df10a4bc33
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/toolz-{{ version }}.tar.gz
+  sha256: 88c570861c440ee3f2f6037c4654613228ff40c93a6c25e0eba70d17282c6194
 
 build:
   number: 0
   skip: True  # [py<35]
-  noarch: python
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
@@ -21,7 +21,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - python >=3.5
+    - python
 
 test:
   imports:
@@ -32,17 +32,17 @@ test:
     - toolz.sandbox
   requires:
     - pip
-    - python <3.10
     - pytest
   commands:
     - pip check
-    - pytest -x --doctest-modules --pyargs toolz
+    - pytest --doctest-modules --pyargs toolz
 
 about:
-  home: http://toolz.readthedocs.org/
+  home: https://toolz.readthedocs.io/
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt
+  license_url: https://github.com/pytoolz/toolz/blob/master/LICENSE.txt
   summary: List processing tools and functional utilities
   description: |
     Toolz provides a set of utility functions for iterators, functions, and
@@ -50,7 +50,7 @@ about:
     blocks of common data analytic operations. They extend the standard
     libraries itertools and functools and borrow heavily from the standard
     libraries of contemporary functional languages.
-  doc_url: http://toolz.readthedocs.org/en/latest/
+  doc_url: https://toolz.readthedocs.io/
   doc_source_url: https://github.com/pytoolz/toolz/blob/master/doc/source/index.rst
   dev_url: https://github.com/pytoolz/toolz
 


### PR DESCRIPTION
**Jira ticket:** [PKG-127](https://anaconda.atlassian.net/browse/PKG-127)

**The upstream data:**
Github releases:  https://github.com/pytoolz/toolz/releases
[Diff between the latest and previous upstream releases](https://github.com/pytoolz/toolz/compare/0.11.2...0.12.0)
Requirements:
 * setup.cfg:  https://github.com/pytoolz/toolz/blob/0.12.0/setup.cfg
 * setup.py:  https://github.com/pytoolz/toolz/blob/0.12.0/setup.py

**_Actions:_**

1. Add jinja2 templates
2. Update `source/url`
3. Fix `python` in `run` because we build an arch-specific package
4. Update `home`, `doc` urls, 
5. Add `license_url`
6. Fix `pytest` command:  remove `-x` flag (so the tests won't interrupt after the first failed test)

**_Notes:_**
 * It's a `conda` dependency, see https://github.com/AnacondaRecipes/conda-feedstock/blob/92ac6eed450ce4ef3ce5585dc13a9c2a9b9ecc06/recipe/meta.yaml#L45

**Package's statistics**
<details>

 * Priority C | effort: easy | Category: anaconda | subcategory: dependency | pkg_type: python
 * Outdated platfroms: 'linux-64', 'linux-aarch64', 'linux-s390x', 'linux-ppc64le', 'osx-64', 'osx-arm64', 'win-64'
 * Latest version: 0.12.0
 * Release on PyPi:
    * version: 0.12.0
    * date: 2022-07-10T04:29:56
* [PyPi history](https://pypi.org/project/toolz/#history)
 * Popularity: 
    * 3 months downloads: 1138065.0
    * All time:  10105664 downloads -  toolz  0.12.0  A functional standard library for Python  

</details>

**Links:**
<details>

* [The v0.12.0 upstream URL](https://github.com/pytoolz/toolz/tree/0.12.0)
* [dev_url](https://github.com/pytoolz/toolz)
* [doc_url](https://toolz.readthedocs.io/)
* [Bug tracker](https://github.com/pytoolz/toolz/issues)
* [PyPi](https://pypi.org/project/toolz)
* [conda-forge recipe](https://github.com/conda-forge/toolz-feedstock/blob/master/recipe/meta.yaml)
* [Anaconda recipe feedstock](https://github.com/AnacondaRecipes/toolz-feedstock)
* [Update branch: _0.12.0_](https://github.com/AnacondaRecipes/toolz-feedstock/tree/0.12.0)
* [Diff between upstream conda-forge **main** and aggregate **feature** branch](https://github.com/conda-forge/toolz-feedstock/compare/main...AnacondaRecipes:0.12.0#files_bucket)
* [Diff between origin aggregate **master** and aggregate **feature** branch](https://github.com/AnacondaRecipes/toolz-feedstock/compare/master...AnacondaRecipes:0.12.0#files_bucket)
* [The last merged PRs](https://github.com/AnacondaRecipes/toolz-feedstock/pulls?q=is%3Apr+is%3Amerged+sort%3Aupdated-desc+)

</details>

**Anaconda Linter:**

<details>

The following problems have been found:

WARNING: /aggregate/toolz-feedstock/recipe/meta.yaml:15: avoid_noarch: noarch: python packages should be avoided
ERROR: /aggregate/toolz-feedstock/recipe/meta.yaml:42: invalid_url: http://toolz.readthedocs.org/ : URL domain redirect toolz.readthedocs.org ->  toolz.readthedocs.io
ERROR: /aggregate/toolz-feedstock/recipe/meta.yaml:53: invalid_url: http://toolz.readthedocs.org/ : URL domain redirect toolz.readthedocs.org ->  toolz.readthedocs.io
WARNING: /aggregate/toolz-feedstock/recipe/meta.yaml:55: missing_license_url: The recipe is missing a license_url
WARNING: /aggregate/toolz-feedstock/recipe/meta.yaml:55: http_url: http://toolz.readthedocs.org/ is not https
Errors were found

</details>

**Other checks:**

<details>

1. - [x] https://github.com/pytoolz/toolz/tree/0.12.0 exists
2. - [x] The upstream url: https://toolz.readthedocs.io/
3. - [x] Check the pinnings
4. - [x] Changelog url: https://github.com/pytoolz/toolz/releases
5. - [x] Additional research
    https://github.com/pytoolz/toolz/issues
    200
6. - [x] `dev_url` is present
    https://github.com/pytoolz/toolz
7. - [x] `doc_url` error: https://toolz.readthedocs.io/
8. - [x] `doc_source_url` is present
    https://github.com/pytoolz/toolz/blob/master/doc/source/index.rst
9. - [x] Verify that the `build_number` is correct
10. - [x] has `setuptools`
11. - [x] has `wheel`
12. - [x] `pip` in test
13. - [x] Verify the test section
14. - [x] Verify if the package is `architecture specific`
15. - [x] Verify that private module are not mentioned on the recipe For example: (_private_module)
16.  - [x] license_file: LICENSE.txt is present
17. - [x] License: BSD-3-Clause
    - [x] License is `spdx` compliant
 * Check if the license identifier has correct name from the SPDX License List

| Identifier                           |
|:-------------------------------------|
| BSD-3-Clause                         |
| BSD-3-Clause-Attribution             |
| BSD-3-Clause-Clear                   |
| BSD-3-Clause-LBNL                    |
| BSD-3-Clause-Modification            |
| BSD-3-Clause-No-Military-License     |
| BSD-3-Clause-No-Nuclear-License      |
| BSD-3-Clause-No-Nuclear-License-2014 |
| BSD-3-Clause-No-Nuclear-Warranty     |
| BSD-3-Clause-Open-MPI                |

18. - [x] license_family BSD is present
</details>


**Updating the recipe:**

If the recipe needs additional modification the update branch can be modified.

```
git clone -b 0.12.0 git@github.com:AnacondaRecipes/toolz-feedstock.git
```

