### PR TITLE
toolz 1.1.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,2 @@
 build_env_vars:
-  ANACONDA_ROCKET_ENABLE_PY313 : yes
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "toolz" %}
-{% set version = "1.0.0" %}
+{% set version = "1.1.0" %}
 
 package:
   name: {{ name|lower }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/toolz-{{ version }}.tar.gz
-  sha256: 2c86e3d9a04798ac556793bced838816296a2f085017664e4995cb40a1047a02
+  sha256: 27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b
 
 build:
   number: 0
@@ -18,8 +18,8 @@ requirements:
   host:
     - python
     - pip
-    - setuptools
-    - wheel
+    - setuptools >=77
+    - setuptools-git-versioning >=2.0
   run:
     - python
 
@@ -35,6 +35,7 @@ test:
     - pytest
   commands:
     - pip check
+    - python -c "import toolz; assert toolz.__version__ != '0.0.0'"
     - pytest --doctest-modules --pyargs toolz
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -11,7 +11,7 @@ source:
 
 build:
   number: 0
-  skip: True  # [py<38]
+  skip: True  # [py<39]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -39,7 +39,7 @@ test:
     - pytest --doctest-modules --pyargs toolz
 
 about:
-  home: https://toolz.readthedocs.io/
+  home: https://github.com/pytoolz/toolz
   license: BSD-3-Clause
   license_family: BSD
   license_file: LICENSE.txt


### PR DESCRIPTION
**Destination channel:** main

### Links

- [Jira](https://anaconda.atlassian.net/browse/PKG-11107) 
- [Upstream repository](https://github.com/pytoolz/toolz/blob/1.1.0/pyproject.toml)

### Explanation of changes:

- Skip py<39
- Update host dependencies

### Notes:

- v1.1.0 supports py314. It's needed for cytoolz https://github.com/AnacondaRecipes/cytoolz-feedstock/pull/7